### PR TITLE
fix(mockGrpcUnary): ensure route registration is awaited to avoid race conditions where a route might be attempted before registration completes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ test.describe('Some test wrapper', () => {
   test('Make sure a grpc call is made and is successful', async ({ page }) => {
     // start by building a mock for the unary call that will be done
     // for example as soon as a given page is loaded
-    const mock = mockGrpcUnary(page, YourUnaryCall, {
+    const mock = await mockGrpcUnary(page, YourUnaryCall, {
       message: YourUnaryCallResponse.encode({
         // all the content of the response goes here as a classic JS object
         // this is the mock data that will be passed in the response

--- a/src/playwright/index.ts
+++ b/src/playwright/index.ts
@@ -39,15 +39,15 @@ export function readGrpcRequest(request: Request): Uint8Array | null {
   return !requestBody ? null : unframeRequest(requestBody);
 }
 
-export function mockGrpcUnary(
+export async function mockGrpcUnary(
   page: Page,
   rpc: UnaryMethodDefinitionish,
   response: GrpcResponse | ((request: Uint8Array | null) => GrpcResponse)
-): MockedGrpcCall {
+): Promise<MockedGrpcCall> {
   const url = `/${rpc.service.serviceName}/${rpc.methodName}`;
 
   // note this wildcard route url base is done in order to match both localhost and deployed service usages.
-  page.route("**" + url, (route) => {
+  await page.route("**" + url, (route) => {
     expect(
       route.request().method(),
       "ALL gRPC requests should be a POST request"


### PR DESCRIPTION
BREAKING CHANGE:

`mockGrpcUnary` is now an `async function`, and so must be awaited to get the `MockedGrpcCall`