### PR TITLE
fix: missing peer dependency

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -20,7 +20,8 @@
   "peerDependencies": {
     "@improbable-eng/grpc-web": "^0.15.0",
     "@playwright/test": "^1.22.2",
-    "grpc": "^1.24.11",
-    "playwright-core": "^1.22.2"
+    "playwright-core": "^1.22.2",
+    "@grpc/grpc-js": "^1.6.10",
+    "google-protobuf": "^3.14.0"
   }
 }


### PR DESCRIPTION
Follow up of https://github.com/cloudnc/grpc-web-testing-toolbox/pull/5 where these changes were forgotten